### PR TITLE
Ensure both boxes are rendered simultaneously

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,64 +5,51 @@
  * 3. Draw squares
  * 4. Movement
  */
+
+
+/* 1. Game canvas */
 const canvas = document.getElementById("ca");
 const ctx = canvas.getContext("2d");
 
 
-ctx.fillStyle = "green";
-let x = 40;
-let y = 200;
-const width = 100;
-const height = 150;
-let speed = 3;
-let intervalId;
-
-
-ctx.fillStyle = "blue";
-ctx.fillRect(20, 100, 50, 75);
-
-function drawSquare2(){
-    ctx.fillStyle = "blue";
-resetCanvas();
-ctx.fillRect(20, 100, 50, 75);
-}
-
-function drawSquare() {
-    ctx.fillStyle= "red";
-    resetCanvas();
-    ctx.fillRect(x, y, width, height);
-}
-
 function resetCanvas() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 }
-setInterval(1000);
-function startMoving(direction) {
-    if (!intervalId) {
-        intervalId = setInterval(() => {
-            moveSquare(direction);
-            drawSquare();
-        }, speed);
-    }
+
+/* 2. Squares Definition */
+
+// Square 1
+const width1 = 100;
+const height1 = 150;
+const color1 = "blue";
+let x1 = 40;
+let y1 = 200;
+let speed1 = 3;
+let intervalId;
+
+// Square 2
+const width2 = 100;
+const height2 = 150;
+const color2 = "green";
+let x2 = 40;
+let y2 = 0;
+let speed2 = 3;
+
+
+/* 3. Draw squares */
+setInterval(drawSquares, 100);
+
+function drawSquares() {
+    resetCanvas();
+
+    ctx.fillStyle = color1;
+    ctx.fillRect(x1, y1, width1, height1);
+
+    ctx.fillStyle = color2;
+    ctx.fillRect(x2, y2, width2, height2);
 }
 
-function stopMoving() {
-    clearInterval(intervalId);
-    intervalId = null;
-}
-
-function moveSquare(direction) {
-    if (direction === "right") {
-        x += speed;
-    } else if (direction === "left") {
-        x -= speed;
-    } else if (direction === "up") {
-        y -= speed;
-    } else if (direction === "down") {
-        y += speed;
-    }
-}
-
+/* 4. Movement */
 document.addEventListener('keydown', (event) => {
     switch (event.key) {
         case 'd':
@@ -99,8 +86,28 @@ document.addEventListener('keyup', (event) => {
     }
 });
 
-drawSquare();
-drawSquare2();
+function startMoving(direction) {
+    if (!intervalId) {
+        intervalId = setInterval(() => {
+            moveSquare(direction);
+            drawSquares();
+        }, speed1);
+    }
+}
 
+function stopMoving() {
+    clearInterval(intervalId);
+    intervalId = null;
+}
 
-
+function moveSquare(direction) {
+    if (direction === "right") {
+        x1 += speed1;
+    } else if (direction === "left") {
+        x1 -= speed1;
+    } else if (direction === "up") {
+        y1 -= speed1;
+    } else if (direction === "down") {
+        y1 += speed1;
+    }
+}

--- a/script.js
+++ b/script.js
@@ -1,3 +1,10 @@
+/*
+ * Table of contents:
+ * 1. Game canvas
+ * 2. Squares definition
+ * 3. Draw squares
+ * 4. Movement
+ */
 const canvas = document.getElementById("ca");
 const ctx = canvas.getContext("2d");
 


### PR DESCRIPTION
To achieve the simultaneous rendering of two squares, distinct
coordinates were assigned to each square. This enables the depiction of
both squares at distinct positions, preventing any conflict in their
attributes.

Previously, there existed a sole square. It might have appeared as if
there were two squares due to alterations in the coordinates and color
of the same square, albeit the square was essentially being repositioned.

Presently, two separate squares are generated, each possessing their
unique coordinates and colors. Furthermore, the drawSquares function has
been modified to render both squares concurrently.

All movement functions and values now reference the values of square1,
for example, what was previously just `x` is now `x1`, `speed` became
`speed1`, etc.

This solution is far from optimal, there is a bunch of opportunity to
improve the code. However, we might not be at that stage yet.

A recommendation moving forward is to try and structure/organise the
code. It will help you when debugging as well as understanding what's
going on.